### PR TITLE
Add manual Actions trigger

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,7 +4,8 @@ on:
     branches:
       - gh-pages
       - main
-  pull_request: []
+  pull_request:
+  workflow_dispatch:
 jobs:
   build-website:
     if: ${{ !endsWith(github.repository, '/styles') }}


### PR DESCRIPTION
This PR adds the manual `workflow_dispatch` Actions trigger to trigger a build via the github gui.

Also, this pull request will trigger the Actions workflow build, which will end up serving the site from your github pages.